### PR TITLE
fix: fix revisionHistoryLimit attribute for kibana

### DIFF
--- a/apigateway/helm/Chart.yaml
+++ b/apigateway/helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/apigateway/helm/templates/kibana.yaml
+++ b/apigateway/helm/templates/kibana.yaml
@@ -27,6 +27,9 @@ spec:
   {{- end }}
   version: {{ .Values.kibana.version }}
   count: {{ .Values.kibana.count }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   config:
     xpack.security.authc.providers:
       anonymous.anonymous1:
@@ -86,9 +89,6 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.revisionHistoryLimit }}
-      revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
-      {{- end }}
       {{- with .Values.kibana.affinity }}
       affinity:
         {{- tpl (toYaml .) $context  | nindent 8 }}


### PR DESCRIPTION
I've found out that the `revisionHistoryLimit` in values.yaml is not working in kibana. The implementation set this in podTemplate which is wrong. Please refer to [kibana.k8s.elastic.co/v1 - KibanaSpec](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-api-kibana-k8s-elastic-co-v1.html#k8s-api-github-com-elastic-cloud-on-k8s-v2-pkg-apis-kibana-v1-kibanaspec).

Note: Please merge this by squashing commits.