### PR TITLE
fix(api-gateway): fixed metadata for api gateway pdb

### DIFF
--- a/apigateway/helm/Chart.yaml
+++ b/apigateway/helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/apigateway/helm/README.md.gotmpl
+++ b/apigateway/helm/README.md.gotmpl
@@ -172,6 +172,7 @@ Sub-folder `examples` contains some *values* examples for more use-cases. To use
 | `2.0.0` | Prometheus Elasticsearch Exporter version `6.5.0` is used. Value `revisionHistoryLimit` is added and documented. |
 | `2.0.1` | Fix `revisionHistoryLimit` for Kibana. |
 | `2.1.0` | Added ability to use PodDisruptionBudget for API Gateway and updated Prometheus Elasticsearch Exporter to `6.6.0` |
+| `2.1.1` | Fixed metadata of PodDisruptionBudget for API Gateway |
 
 ## Chart Version `2.0.0`
 

--- a/apigateway/helm/templates/poddisruptionbudget.yaml
+++ b/apigateway/helm/templates/poddisruptionbudget.yaml
@@ -1,6 +1,13 @@
 {{- if .Values.podDisruptionBudget.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
+metadata:
+  name: name: {{ include "common.names.fullname" . }}-pdb
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+    {{- with .Values.extraLabels -}}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- toYaml (required "A valid PodDisruptionBudgetSpec is required!" .Values.podDisruptionBudget.spec) | nindent 2 }}
   selector:


### PR DESCRIPTION
Hi @thomas-2020 ,
I accidentally forgot to set the metadata for the api gateway PodDisruptionBudget.
In my local `helm template` it looks like it works. But now in my deployment it doesn't. So that's why I raise a fixe pr here.
Please update the `README.md` from the gotemplate and consider merging my squashing commits.
Regards