### PR TITLE
fix(apigateway): fixed proxy-connect-timeout ingress annotation

### DIFF
--- a/apigateway/helm/Chart.yaml
+++ b/apigateway/helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/apigateway/helm/README.md
+++ b/apigateway/helm/README.md
@@ -174,7 +174,7 @@ Sub-folder `examples` contains some *values* examples for more use-cases. To use
 | `2.1.0` | Added ability to use PodDisruptionBudget for API Gateway and updated Prometheus Elasticsearch Exporter to `6.6.0` |
 | `2.1.1` | Fixed metadata of PodDisruptionBudget for API Gateway |
 | `2.1.2` | Fixed metadata.name of PodDisruptionBudget for API Gateway |
-| `2.1.2` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
+| `2.1.3` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
 
 ## Chart Version `2.0.0`
 

--- a/apigateway/helm/README.md
+++ b/apigateway/helm/README.md
@@ -174,6 +174,7 @@ Sub-folder `examples` contains some *values* examples for more use-cases. To use
 | `2.1.0` | Added ability to use PodDisruptionBudget for API Gateway and updated Prometheus Elasticsearch Exporter to `6.6.0` |
 | `2.1.1` | Fixed metadata of PodDisruptionBudget for API Gateway |
 | `2.1.2` | Fixed metadata.name of PodDisruptionBudget for API Gateway |
+| `2.1.2` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
 
 ## Chart Version `2.0.0`
 
@@ -298,8 +299,8 @@ kubectl delete deployment <Helm-release-name>-prometheus-elasticsearch-exporter 
 | ingress.tls.secretProviderParameters | object | `{}` |  |
 | ingresses.admin.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
 | ingresses.admin.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"10m"` |  |
+| ingresses.admin.annotations."nginx.ingress.kubernetes.io/proxy-connect-timeout" | string | `"600"` |  |
 | ingresses.admin.annotations."nginx.ingress.kubernetes.io/proxy-read-timeout" | string | `"600"` |  |
-| ingresses.admin.annotations."nginx.ingress.kubernetes.io/proxy_connect_timeout" | string | `"600"` |  |
 | ingresses.admin.className | string | `"nginx"` |  |
 | ingresses.admin.defaultHost | string | `""` |  |
 | ingresses.admin.enabled | bool | `true` |  |
@@ -313,8 +314,8 @@ kubectl delete deployment <Helm-release-name>-prometheus-elasticsearch-exporter 
 | ingresses.admin.tls[0].secretProviderEnabled | bool | `false` |  |
 | ingresses.admin.tls[0].secretProviderSecretName | string | `nil` |  |
 | ingresses.rt.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"10m"` |  |
+| ingresses.rt.annotations."nginx.ingress.kubernetes.io/proxy-connect-timeout" | string | `"600"` |  |
 | ingresses.rt.annotations."nginx.ingress.kubernetes.io/proxy-read-timeout" | string | `"600"` |  |
-| ingresses.rt.annotations."nginx.ingress.kubernetes.io/proxy_connect_timeout" | string | `"600"` |  |
 | ingresses.rt.className | string | `"nginx"` |  |
 | ingresses.rt.defaultHost | string | `""` |  |
 | ingresses.rt.enabled | bool | `true` |  |
@@ -329,8 +330,8 @@ kubectl delete deployment <Helm-release-name>-prometheus-elasticsearch-exporter 
 | ingresses.rt.tls[0].secretProviderSecretName | string | `nil` |  |
 | ingresses.ui.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
 | ingresses.ui.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"10m"` |  |
+| ingresses.ui.annotations."nginx.ingress.kubernetes.io/proxy-connect-timeout" | string | `"600"` |  |
 | ingresses.ui.annotations."nginx.ingress.kubernetes.io/proxy-read-timeout" | string | `"600"` |  |
-| ingresses.ui.annotations."nginx.ingress.kubernetes.io/proxy_connect_timeout" | string | `"600"` |  |
 | ingresses.ui.className | string | `"nginx"` |  |
 | ingresses.ui.defaultHost | string | `""` |  |
 | ingresses.ui.enabled | bool | `true` |  |

--- a/apigateway/helm/README.md.gotmpl
+++ b/apigateway/helm/README.md.gotmpl
@@ -174,7 +174,7 @@ Sub-folder `examples` contains some *values* examples for more use-cases. To use
 | `2.1.0` | Added ability to use PodDisruptionBudget for API Gateway and updated Prometheus Elasticsearch Exporter to `6.6.0` |
 | `2.1.1` | Fixed metadata of PodDisruptionBudget for API Gateway |
 | `2.1.2` | Fixed metadata.name of PodDisruptionBudget for API Gateway |
-| `2.1.2` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
+| `2.1.3` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
 
 ## Chart Version `2.0.0`
 

--- a/apigateway/helm/README.md.gotmpl
+++ b/apigateway/helm/README.md.gotmpl
@@ -174,6 +174,7 @@ Sub-folder `examples` contains some *values* examples for more use-cases. To use
 | `2.1.0` | Added ability to use PodDisruptionBudget for API Gateway and updated Prometheus Elasticsearch Exporter to `6.6.0` |
 | `2.1.1` | Fixed metadata of PodDisruptionBudget for API Gateway |
 | `2.1.2` | Fixed metadata.name of PodDisruptionBudget for API Gateway |
+| `2.1.2` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
 
 ## Chart Version `2.0.0`
 

--- a/apigateway/helm/values.yaml
+++ b/apigateway/helm/values.yaml
@@ -128,7 +128,7 @@ ingresses:
       nginx.ingress.kubernetes.io/affinity: "cookie"
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-      nginx.ingress.kubernetes.io/proxy_connect_timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
       # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     hosts:
       - host:
@@ -150,7 +150,7 @@ ingresses:
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-      nginx.ingress.kubernetes.io/proxy_connect_timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
       # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     hosts:
       - host:
@@ -172,7 +172,7 @@ ingresses:
       nginx.ingress.kubernetes.io/affinity: "cookie"
       nginx.ingress.kubernetes.io/proxy-body-size: 10m
       nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
-      nginx.ingress.kubernetes.io/proxy_connect_timeout: "600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "600"
       # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     hosts:
       - host:


### PR DESCRIPTION
Hi @thomas-2020,
I stumbled across this wrong annotation in our deployments. So i decided to it this here.
More information: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts
Regards