### PR TITLE
feat(apigateway): add startup, liveness, and readiness probes configuration in values file

### DIFF
--- a/apigateway/helm/Chart.yaml
+++ b/apigateway/helm/Chart.yaml
@@ -33,7 +33,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.3
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/apigateway/helm/README.md.gotmpl
+++ b/apigateway/helm/README.md.gotmpl
@@ -175,6 +175,7 @@ Sub-folder `examples` contains some *values* examples for more use-cases. To use
 | `2.1.1` | Fixed metadata of PodDisruptionBudget for API Gateway |
 | `2.1.2` | Fixed metadata.name of PodDisruptionBudget for API Gateway |
 | `2.1.3` | Fixed proxy connect timeout annotation on all ingresses for API Gateway |
+| `2.2.0` | Add functionality to define startup, liveness and readiness probes for API Gateway in the values file. |
 
 ## Chart Version `2.0.0`
 

--- a/apigateway/helm/templates/deployment.yaml
+++ b/apigateway/helm/templates/deployment.yaml
@@ -187,21 +187,17 @@ spec:
           livenessProbe:
             tcpSocket:
               port: {{ int .Values.apigw.adminPort }}
-            failureThreshold: 3
-            initialDelaySeconds: 120
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 1
+            {{- toYaml .Values.apigw.livenessProbe | nindent 12 }}
+          startupProbe:
+            tcpSocket:
+              port: {{ int .Values.apigw.adminPort }}
+            {{- toYaml .Values.apigw.startupProbe | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /rest/apigateway/health
               port: {{ int .Values.apigw.adminPort }}
               scheme: {{ .Values.apigw.readinessProbe.scheme }}
-            failureThreshold: 3
-            initialDelaySeconds: 30
-            periodSeconds: 30
-            successThreshold: 1
-            timeoutSeconds: 1
+            {{- toYaml .Values.apigw.readinessProbe.fields | nindent 12 }}
           resources:
             {{- toYaml .Values.resources.apigwContainer | nindent 12 }}
           volumeMounts:

--- a/apigateway/helm/values.yaml
+++ b/apigateway/helm/values.yaml
@@ -331,10 +331,30 @@ apigw:
   runtimeExternalPort:     6555
   # -- gRPC port for High Availability and Fault Tolerance (HAFT) solution. This port must be manually setup after API Gateway was initizalized.
   grpcPort:                4440
+  # -- readinessProbe configuration for API Gateway container. The readiness probe is used to determine if the container is ready to accept traffic.
   readinessProbe:
-    # -- The readinessprobe scheme (https or http).
-    scheme:                "HTTP"
-  serviceName:             "apigw"
+    fields:
+      failureThreshold: 3
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      successThreshold: 1
+      timeoutSeconds: 1
+    # -- The readiness probe scheme (https or http).
+    scheme: "HTTP"
+  # -- livenessProbe configuration for API Gateway container. The liveness probe is used to determine if the container is still running.
+  livenessProbe:
+    failureThreshold: 3
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
+  # -- startupProbe configuration for API Gateway container. Runs before the livenessProbe. It is used to determine if the container has finished starting.
+  startupProbe:
+    failureThreshold: 12
+    periodSeconds: 30
+    successThreshold: 1
+    timeoutSeconds: 1
+  serviceName: "apigw"
 
   # -- SecurityContext for apigw initContainer
   # Deactivated by default.


### PR DESCRIPTION
- added functionality to change values of liveness and readiness probe in values.yaml
- created "fields" under readinessProbe in values.yaml to keep change backwards compatible
- added startup probe to allow for smaller timeout value in liveness probe
- update chart version to 2.2.0
- update readme.gotmpl