### PR TITLE
various fixes and added features for the api control plane chart

### DIFF
--- a/apicontrolplane/helm/Chart.yaml
+++ b/apicontrolplane/helm/Chart.yaml
@@ -33,12 +33,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 11.1
+appVersion: "11.1"
 
 dependencies:
 - name: common

--- a/apicontrolplane/helm/templates/assetcatalog_deployment.yaml
+++ b/apicontrolplane/helm/templates/assetcatalog_deployment.yaml
@@ -92,5 +92,5 @@ spec:
           timeoutSeconds: 15
       terminationGracePeriodSeconds: 30
       imagePullSecrets:
-          - name: regcred
+        - name: {{ .Values.imagePullSecretName }}
 ---

--- a/apicontrolplane/helm/templates/assetcatalog_deployment.yaml
+++ b/apicontrolplane/helm/templates/assetcatalog_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         app: {{ .Values.applications.assetcatalog.name }}
         date: "{{ now | unixEpoch }}"
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: false
       volumes:
       - name: certs

--- a/apicontrolplane/helm/templates/datastore_statefulset.yaml
+++ b/apicontrolplane/helm/templates/datastore_statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       securityContext:
         fsGroup: 1000
       imagePullSecrets:
-          - name: regcred
+          - name: {{ .Values.imagePullSecretName }}
       initContainers:
       - name: init-sysctl
         image: alpine:latest

--- a/apicontrolplane/helm/templates/datastore_statefulset.yaml
+++ b/apicontrolplane/helm/templates/datastore_statefulset.yaml
@@ -47,6 +47,7 @@ spec:
       labels:
         app: {{ .Values.applications.datastore.name }}
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       securityContext:
         fsGroup: 1000
       imagePullSecrets:

--- a/apicontrolplane/helm/templates/engine_deployment.yaml
+++ b/apicontrolplane/helm/templates/engine_deployment.yaml
@@ -92,5 +92,5 @@ spec:
           timeoutSeconds: 15
       terminationGracePeriodSeconds: 30
       imagePullSecrets:
-          - name: regcred
+          - name: {{ .Values.imagePullSecretName }}
 ---

--- a/apicontrolplane/helm/templates/engine_deployment.yaml
+++ b/apicontrolplane/helm/templates/engine_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         app: {{ .Values.applications.engine.name }}
         date: "{{ now | unixEpoch }}"
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: false
       volumes:
       - name: certs

--- a/apicontrolplane/helm/templates/ingress_deployment.yaml
+++ b/apicontrolplane/helm/templates/ingress_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         app: {{ .Values.applications.ingress.name }}
         date: "{{ now | unixEpoch }}"
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: false
       volumes:
       - name: license-file

--- a/apicontrolplane/helm/templates/ingress_deployment.yaml
+++ b/apicontrolplane/helm/templates/ingress_deployment.yaml
@@ -99,5 +99,5 @@ spec:
           timeoutSeconds: 15
       terminationGracePeriodSeconds: 30
       imagePullSecrets:
-          - name: regcred
+          - name: {{ .Values.imagePullSecretName }}
 ---

--- a/apicontrolplane/helm/templates/ingress_external.yaml
+++ b/apicontrolplane/helm/templates/ingress_external.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  namespace: {{ default "control-plane" .Release.Namespace }}
+  annotations:
+  {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ if eq .Values.applications.ingress.sslEnabled true }}
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  {{ end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.domainName }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: 
+                name: {{ .Values.applications.ingress.name }}
+                port: 
+                  {{- if eq .Values.applications.ingress.sslEnabled true }}
+                  number: 8443
+                  {{- else }}
+                  number: 8080
+                  {{- end }}
+{{- end }}

--- a/apicontrolplane/helm/templates/jaegar_deployment.yaml
+++ b/apicontrolplane/helm/templates/jaegar_deployment.yaml
@@ -33,6 +33,7 @@ spec:
         app: {{ .Values.applications.jaegertracing.name }}
       annotations:
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: false
       containers:
       - image: {{ .Values.applications.jaegertracing.imageName }}:{{ .Values.applications.jaegertracing.imageTag }}

--- a/apicontrolplane/helm/templates/kube_ingress.yaml
+++ b/apicontrolplane/helm/templates/kube_ingress.yaml
@@ -8,11 +8,6 @@ metadata:
   {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{ if eq .Values.applications.ingress.sslEnabled true }}
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  {{ end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/apicontrolplane/helm/templates/nginx_configmap.yaml
+++ b/apicontrolplane/helm/templates/nginx_configmap.yaml
@@ -16,6 +16,7 @@
 #  *   limitations under the License.
 #  *
 #  */
+{{- if not .Values.ingress.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -45,3 +46,4 @@ data:
                proxy_ssl_verify off;
            }
      }
+{{- end }}

--- a/apicontrolplane/helm/templates/nginx_deployment.yaml
+++ b/apicontrolplane/helm/templates/nginx_deployment.yaml
@@ -56,6 +56,6 @@ spec:
         secret:
           secretName: {{ .Values.secrets.certs.name }}
       imagePullSecrets:
-        - name: regcred
+        - name: {{ .Values.imagePullSecretName }}
 {{- end }}
         

--- a/apicontrolplane/helm/templates/nginx_deployment.yaml
+++ b/apicontrolplane/helm/templates/nginx_deployment.yaml
@@ -16,6 +16,7 @@
 #  *   limitations under the License.
 #  *
 #  */
+{{- if not .Values.ingress.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,6 +31,7 @@ spec:
       labels:
         app: nginx
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: nginx
         image: nginx:latest
@@ -55,4 +57,5 @@ spec:
           secretName: {{ .Values.secrets.certs.name }}
       imagePullSecrets:
         - name: regcred
+{{- end }}
         

--- a/apicontrolplane/helm/templates/nginx_service.yaml
+++ b/apicontrolplane/helm/templates/nginx_service.yaml
@@ -16,6 +16,7 @@
 #  *   limitations under the License.
 #  *
 #  */
+{{- if not .Values.ingress.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,3 +29,4 @@ spec:
     - protocol: TCP
       port: 443
       targetPort: 443
+{{- end }}

--- a/apicontrolplane/helm/templates/service_account.yaml
+++ b/apicontrolplane/helm/templates/service_account.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/apicontrolplane/helm/templates/ui_deployment.yaml
+++ b/apicontrolplane/helm/templates/ui_deployment.yaml
@@ -92,5 +92,5 @@ spec:
           timeoutSeconds: 15
       terminationGracePeriodSeconds: 30
       imagePullSecrets:
-          - name: regcred
+          - name: {{ .Values.imagePullSecretName }}
 ---

--- a/apicontrolplane/helm/templates/ui_deployment.yaml
+++ b/apicontrolplane/helm/templates/ui_deployment.yaml
@@ -38,6 +38,7 @@ spec:
         app: {{ .Values.applications.ui.name }}      
         date: "{{ now | unixEpoch }}"
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       automountServiceAccountToken: false
       volumes:
       - name: certs

--- a/apicontrolplane/helm/values.yaml
+++ b/apicontrolplane/helm/values.yaml
@@ -150,3 +150,40 @@ domainName: localhost
 imagePullSecretName: regcred
 # -- Optionally configure a ingress class to use for the kubernetes ingress (default: nginx)
 # ingressClassName: nginx
+
+
+# -- if es_external = true, that means you want to use an external elastic search... 
+# and the built-in ES will not be deployed and ignored
+es_external:
+  enabled: false
+  connection:
+    host: "external-elastic-host"
+    port: "9200"
+    auth:
+      userName: elastic
+      passwordSecret:
+        name: ""
+        key: ""
+      certsSecret:
+        name: ""
+        key: ""
+
+serviceAccount:
+  # The name of the service account to use.
+  name: "apicp-sa"
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  
+ingress:
+  enabled: false
+  name: apicp-ingress
+  domainName: my-control-plane
+  # className: "ingress-controller-class"
+  annotations: {}
+    # kubernetes.io/tls-acme: "true"
+  # tls:
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/apicontrolplane/helm/values.yaml
+++ b/apicontrolplane/helm/values.yaml
@@ -148,9 +148,6 @@ secrets:
 
 domainName: localhost
 imagePullSecretName: regcred
-# -- Optionally configure a ingress class to use for the kubernetes ingress (default: nginx)
-# ingressClassName: nginx
-
 
 # -- if es_external = true, that means you want to use an external elastic search... 
 # and the built-in ES will not be deployed and ignored

--- a/apicontrolplane/helm/values.yaml
+++ b/apicontrolplane/helm/values.yaml
@@ -149,22 +149,6 @@ secrets:
 domainName: localhost
 imagePullSecretName: regcred
 
-# -- if es_external = true, that means you want to use an external elastic search... 
-# and the built-in ES will not be deployed and ignored
-es_external:
-  enabled: false
-  connection:
-    host: "external-elastic-host"
-    port: "9200"
-    auth:
-      userName: elastic
-      passwordSecret:
-        name: ""
-        key: ""
-      certsSecret:
-        name: ""
-        key: ""
-
 serviceAccount:
   # The name of the service account to use.
   name: "apicp-sa"

--- a/apicontrolplane/helm/values.yaml
+++ b/apicontrolplane/helm/values.yaml
@@ -84,7 +84,7 @@ applications:
         # -- Minimum Memory resource units
         memory: 512Mi
     logLevel: TRACE
-    springCodecMaxMemorySize: 5242880
+    springCodecMaxMemorySize: 5MB
   datastore:
     name: datastore
     # -- Opensearch image name


### PR DESCRIPTION
- Externalize value for image pull secret (no reason to force the secret name in the code)
- adding ability to leverage a kubernetes ingress resource (instead of some built-in nginx load balancer)
- disabling the nginx-* resources if "kubernetes ingress" is enabled
- adding service account (needed sometimes for deployments into openshift for example)
- fixed springCodecMaxMemorySize value with supported format (was giving me error)