### PR TITLE
[RNDXPC-2998][terracottabigmemorymax] Migrate to new docker standard layout in version >= 4.5.0

### DIFF
--- a/terracottabigmemorymax/helm/Chart.yaml
+++ b/terracottabigmemorymax/helm/Chart.yaml
@@ -33,12 +33,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "1.4.0"
+version: "2.0.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "4.4.0"
+appVersion: "4.5.0"
 
 dependencies:
 - name: common

--- a/terracottabigmemorymax/helm/README.md
+++ b/terracottabigmemorymax/helm/README.md
@@ -52,18 +52,18 @@ Suppose you are creating a 2*1 bigmemory cluster and 1 tmc then Create a secret 
 ````
 Terracotta Command Line Tools - Keychain Client
 tc://user@terracotta-1.terracotta-service.default.svc.cluster.local:9540 : chunuAa1$
-file:/opt/softwareag/.tc/mgmt/truststore.jks : chunuAa1$
-file:/opt/softwareag/run/truststore.jks : chunuAa1$
+file:/opt/terracotta/.tc/mgmt/truststore.jks : chunuAa1$
+file:/opt/terracotta/run/truststore.jks : chunuAa1$
 tc://user@terracotta-1.terracotta-service.default.svc.cluster.local:9510 : chunuAa1$
 tc://user@terracotta-1.terracotta-service.default.svc.cluster.local:9530 : chunuAa1$
-file:/opt/softwareag/.tc/mgmt/tmc-0-keystore.jks : chunuAa1$
+file:/opt/terracotta/.tc/mgmt/tmc-0-keystore.jks : chunuAa1$
 https://terracotta-1.terracotta-service.default.svc.cluster.local:9540/tc-management-api : chunuAa1$
 https://terracotta-0.terracotta-service.default.svc.cluster.local:9540/tc-management-api : chunuAa1$
 tc://user@terracotta-0.terracotta-service.default.svc.cluster.local:9510 : chunuAa1$
-jks:terracotta-0-alias@/opt/softwareag/run/terracotta-0-keystore.jks : chunuAa1$
+jks:terracotta-0-alias@/opt/terracotta/run/terracotta-0-keystore.jks : chunuAa1$
 tc://user@terracotta-0.terracotta-service.default.svc.cluster.local:9540 : chunuAa1$
 tc://user@terracotta-0.terracotta-service.default.svc.cluster.local:9530 : chunuAa1$
-jks:terracotta-1-alias@/opt/softwareag/run/terracotta-1-keystore.jks : chunuAa1$
+jks:terracotta-1-alias@/opt/terracotta/run/terracotta-1-keystore.jks : chunuAa1$
 ````
 
 - tmc-https.ini :- For enabling ssl connections in jetty. For ex-

--- a/terracottabigmemorymax/helm/README.md.gotmpl
+++ b/terracottabigmemorymax/helm/README.md.gotmpl
@@ -52,18 +52,18 @@ Suppose you are creating a 2*1 bigmemory cluster and 1 tmc then Create a secret 
 ````
 Terracotta Command Line Tools - Keychain Client
 tc://user@terracotta-1.terracotta-service.default.svc.cluster.local:9540 : chunuAa1$
-file:/opt/softwareag/.tc/mgmt/truststore.jks : chunuAa1$
-file:/opt/softwareag/run/truststore.jks : chunuAa1$
+file:/opt/terracotta/.tc/mgmt/truststore.jks : chunuAa1$
+file:/opt/terracotta/run/truststore.jks : chunuAa1$
 tc://user@terracotta-1.terracotta-service.default.svc.cluster.local:9510 : chunuAa1$
 tc://user@terracotta-1.terracotta-service.default.svc.cluster.local:9530 : chunuAa1$
-file:/opt/softwareag/.tc/mgmt/tmc-0-keystore.jks : chunuAa1$
+file:/opt/terracotta/.tc/mgmt/tmc-0-keystore.jks : chunuAa1$
 https://terracotta-1.terracotta-service.default.svc.cluster.local:9540/tc-management-api : chunuAa1$
 https://terracotta-0.terracotta-service.default.svc.cluster.local:9540/tc-management-api : chunuAa1$
 tc://user@terracotta-0.terracotta-service.default.svc.cluster.local:9510 : chunuAa1$
-jks:terracotta-0-alias@/opt/softwareag/run/terracotta-0-keystore.jks : chunuAa1$
+jks:terracotta-0-alias@/opt/terracotta/run/terracotta-0-keystore.jks : chunuAa1$
 tc://user@terracotta-0.terracotta-service.default.svc.cluster.local:9540 : chunuAa1$
 tc://user@terracotta-0.terracotta-service.default.svc.cluster.local:9530 : chunuAa1$
-jks:terracotta-1-alias@/opt/softwareag/run/terracotta-1-keystore.jks : chunuAa1$
+jks:terracotta-1-alias@/opt/terracotta/run/terracotta-1-keystore.jks : chunuAa1$
 ````
 
 - tmc-https.ini :- For enabling ssl connections in jetty. For ex-

--- a/terracottabigmemorymax/helm/templates/server-configmap.yaml
+++ b/terracottabigmemorymax/helm/templates/server-configmap.yaml
@@ -45,23 +45,23 @@ data:
             <tsa-port>{{ $.Values.terracotta.tsaPort }} </tsa-port>
             <tsa-group-port>{{ $.Values.terracotta.tsaGroupPort }}</tsa-group-port>
             <management-port>{{ $.Values.terracotta.tsaManagementPort }}</management-port>
-            <data>/opt/softwareag/run/data</data>
-            <logs>/opt/softwareag/run/logs</logs>
+            <data>/opt/terracotta/run/data</data>
+            <logs>/opt/terracotta/run/logs</logs>
             <dataStorage size={{ $.Values.terracotta.datastoreSize | quote }}>
               <offheap size={{ $.Values.terracotta.offHeapSize | quote }}/>
             </dataStorage>
             {{- if eq $.Values.terracotta.security true }}
             <security>
               <ssl>
-                <certificate>jks:terracotta-{{ add (mul $i $.Values.terracotta.nodeCountPerStripe) $j }}-alias@/opt/softwareag/run/terracotta-{{ add (mul $i $.Values.terracotta.nodeCountPerStripe) $j }}-keystore.jks</certificate>
+                <certificate>jks:terracotta-{{ add (mul $i $.Values.terracotta.nodeCountPerStripe) $j }}-alias@/opt/terracotta/run/terracotta-{{ add (mul $i $.Values.terracotta.nodeCountPerStripe) $j }}-keystore.jks</certificate>
               </ssl>
               <keychain>
                 <class>com.terracotta.management.keychain.FileStoreKeyChain</class>
-                <url>file:/opt/softwareag/run/keychain</url>
+                <url>file:/opt/terracotta/run/keychain</url>
               </keychain>
               <auth>
                 <realm>com.tc.net.core.security.ShiroIniRealm</realm>
-                <url>file:/opt/softwareag/run/terracotta.ini</url>
+                <url>file:/opt/terracotta/run/terracotta.ini</url>
                 <user>user</user>
               </auth>
               <management>

--- a/terracottabigmemorymax/helm/templates/tc-server-statefulset.yaml
+++ b/terracottabigmemorymax/helm/templates/tc-server-statefulset.yaml
@@ -64,16 +64,16 @@ spec:
           {{- end }}
           volumeMounts:
             - name: commonconfig-volume
-              mountPath: /opt/softwareag/config
+              mountPath: /opt/terracotta/config
             - name: core-store
-              mountPath: /opt/softwareag/run
+              mountPath: /opt/terracotta/run
           env:
             - name: JSON_LOGGING
               value: {{ $.Values.terracotta.jsonLogging | quote }}
             {{- if eq $.Values.terracotta.security true }}
             {{- if eq $.Values.terracotta.selfSignedCerts true }}
             - name: JAVA_OPTS
-              value: {{ $.Values.terracotta.serverOpts }} -Djavax.net.ssl.trustStore=/opt/softwareag/run/truststore.jks
+              value: {{ $.Values.terracotta.serverOpts }} -Djavax.net.ssl.trustStore=/opt/terracotta/run/truststore.jks
             {{- else }} 
             {{- if ne $.Values.terracotta.serverOpts "" }}
             - name: JAVA_OPTS

--- a/terracottabigmemorymax/helm/templates/tmc-statefulset.yaml
+++ b/terracottabigmemorymax/helm/templates/tmc-statefulset.yaml
@@ -65,17 +65,17 @@ spec:
           {{- end }}
           volumeMounts:
             - name: commonconfig-volume
-              mountPath: /opt/softwareag/config
+              mountPath: /opt/terracotta/config
             - name: core-store
-              mountPath: /opt/softwareag/.tc/mgmt
+              mountPath: /opt/terracotta/.tc/mgmt
           env:
             {{- if eq $.Values.terracotta.security true }}
             {{- if eq $.Values.terracotta.selfSignedCerts true }}
             - name: JAVA_OPTS
-              value: {{ $.Values.terracotta.tmcOpts }} -Djavax.net.ssl.keyStore=/opt/softwareag/.tc/mgmt/tmc-0-keystore.jks -Djavax.net.ssl.trustStore=/opt/softwareag/.tc/mgmt/truststore.jks
+              value: {{ $.Values.terracotta.tmcOpts }} -Djavax.net.ssl.keyStore=/opt/terracotta/.tc/mgmt/tmc-0-keystore.jks -Djavax.net.ssl.trustStore=/opt/terracotta/.tc/mgmt/truststore.jks
             {{- else }}
             - name: JAVA_OPTS
-              value: {{ $.Values.terracotta.tmcOpts }} -Djavax.net.ssl.keyStore=/opt/softwareag/.tc/mgmt/tmc-0-keystore.jks
+              value: {{ $.Values.terracotta.tmcOpts }} -Djavax.net.ssl.keyStore=/opt/terracotta/.tc/mgmt/tmc-0-keystore.jks
             {{- end }}
             {{- else }}
             {{- if ne $.Values.terracotta.tmcOpts "" }}


### PR DESCRIPTION
Following commit `RNDXPC-2998 Migrate to new docker standard layout` in BigMemory source does, which is now in `release/4.5.0` branch, we also need to change the paths in the BM helm charts.