### PR TITLE
Fix/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Each chart has a README for *how to use* and lists some prerequisites.
 
 Per default, Helm uses the latest version on release installation. If you have successfully installed a webMethods release, you should notice the current used Chart version. Therefore, on further release installation or upgrades (with `helm upgrade --install`) you should use the `--version X.Y.Z` to guarantee that the same is installed everywhere.
 
+**Compatibility matrix:**
+
+| NAME                              | CHART VERSION | APP VERSION |
+|:----------------------------------|:-------------:|:-----------:|
+| webmethods/terracottabigmemorymax |  `>= 2.0.1`   |   `4.5.0`   |
+| webmethods/terracottabigmemorymax |  `<= 1.4.0`   |   `4.4.0`   |     
+
 ## Utilities
 
 To adopt Microservices Runtime for your deployment and environment or to build images, there is a collection of utilities:


### PR DESCRIPTION
Add a compatibility matrix table in the version section of the README to warn users about which Helm Chart version is compatible with which app version.